### PR TITLE
non-prod/foobar-dev namespace

### DIFF
--- a/non-prod/foobar-dev-namespace.yaml
+++ b/non-prod/foobar-dev-namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/description: foobar
+  labels:
+    application: foobar
+    size: small
+    team: mike
+    environment: dev
+  name: foobar-


### PR DESCRIPTION
This is a request for the creation of the foobar-dev namespace in the non-prod from the group:default/mike team